### PR TITLE
Issue #2: Login token hardening with refresh rotation

### DIFF
--- a/backend/alembic/versions/20260213_000002_create_refresh_tokens.py
+++ b/backend/alembic/versions/20260213_000002_create_refresh_tokens.py
@@ -1,0 +1,40 @@
+"""create refresh tokens
+
+Revision ID: 20260213_000002
+Revises: 20260213_000001
+Create Date: 2026-02-13 08:40:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "20260213_000002"
+down_revision: Union[str, None] = "20260213_000001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "refresh_tokens",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_refresh_tokens_user_id"), "refresh_tokens", ["user_id"], unique=False)
+    op.create_index(op.f("ix_refresh_tokens_token_hash"), "refresh_tokens", ["token_hash"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_refresh_tokens_token_hash"), table_name="refresh_tokens")
+    op.drop_index(op.f("ix_refresh_tokens_user_id"), table_name="refresh_tokens")
+    op.drop_table("refresh_tokens")
+

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -5,8 +5,9 @@ from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
-from app.core.security import create_token, get_password_hash, verify_password
+from app.core.security import create_token, decode_token, get_password_hash, hash_token, verify_password
 from app.db.session import get_db
+from app.models.auth import RefreshToken
 from app.models.billing import Subscription
 from app.models.user import User
 
@@ -23,6 +24,10 @@ class LoginRequest(BaseModel):
     password: str
 
 
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
 class UserResponse(BaseModel):
     id: str
     email: EmailStr
@@ -36,6 +41,19 @@ class AuthResponse(BaseModel):
     refresh_token: str
     token_type: str = "bearer"
     user: UserResponse
+
+
+def _to_user_response(user: User) -> UserResponse:
+    return UserResponse(id=user.id, email=user.email, role=user.role, mfa_enabled=user.mfa_enabled, status=user.status)
+
+
+def _issue_token_pair(db: Session, user: User) -> tuple[str, str]:
+    access_token = create_token(user.id, settings.access_token_expire_minutes, token_type="access")
+    refresh_token = create_token(user.id, settings.refresh_token_expire_minutes, token_type="refresh")
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(minutes=settings.refresh_token_expire_minutes)
+
+    db.add(RefreshToken(user_id=user.id, token_hash=hash_token(refresh_token), expires_at=expires_at))
+    return access_token, refresh_token
 
 
 @router.post("/register", status_code=status.HTTP_201_CREATED)
@@ -57,18 +75,15 @@ def register(payload: RegisterRequest, db: Session = Depends(get_db)) -> AuthRes
         current_period_end=now + timedelta(days=30),
     )
     db.add(sub)
+
+    access_token, refresh_token = _issue_token_pair(db, user)
     db.commit()
     db.refresh(user)
-
-    access_token = create_token(user.id, settings.access_token_expire_minutes, token_type="access")
-    refresh_token = create_token(user.id, settings.refresh_token_expire_minutes, token_type="refresh")
 
     return AuthResponse(
         access_token=access_token,
         refresh_token=refresh_token,
-        user=UserResponse(
-            id=user.id, email=user.email, role=user.role, mfa_enabled=user.mfa_enabled, status=user.status
-        ),
+        user=_to_user_response(user),
     )
 
 
@@ -78,13 +93,55 @@ def login(payload: LoginRequest, db: Session = Depends(get_db)) -> AuthResponse:
     if user is None or not verify_password(payload.password, user.password_hash):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid credentials")
 
-    access_token = create_token(user.id, settings.access_token_expire_minutes, token_type="access")
-    refresh_token = create_token(user.id, settings.refresh_token_expire_minutes, token_type="refresh")
+    access_token, refresh_token = _issue_token_pair(db, user)
+    db.commit()
 
     return AuthResponse(
         access_token=access_token,
         refresh_token=refresh_token,
-        user=UserResponse(
-            id=user.id, email=user.email, role=user.role, mfa_enabled=user.mfa_enabled, status=user.status
-        ),
+        user=_to_user_response(user),
+    )
+
+
+@router.post("/refresh")
+def refresh_token(payload: RefreshRequest, db: Session = Depends(get_db)) -> AuthResponse:
+    try:
+        decoded = decode_token(payload.refresh_token)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid refresh token") from exc
+
+    token_type = decoded.get("type")
+    user_id = decoded.get("sub")
+    token_exp = decoded.get("exp")
+    if token_type != "refresh" or not isinstance(user_id, str):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid refresh token")
+
+    stored_token = (
+        db.query(RefreshToken)
+        .filter(
+            RefreshToken.user_id == user_id,
+            RefreshToken.token_hash == hash_token(payload.refresh_token),
+            RefreshToken.revoked_at.is_(None),
+        )
+        .first()
+    )
+    if stored_token is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="refresh token revoked or unknown")
+
+    expires_at = datetime.fromtimestamp(token_exp, tz=timezone.utc) if isinstance(token_exp, int) else stored_token.expires_at
+    if expires_at < datetime.now(tz=timezone.utc):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="refresh token expired")
+
+    user = db.query(User).filter(User.id == user_id).first()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="user not found")
+
+    stored_token.revoked_at = datetime.now(tz=timezone.utc)
+    access_token, new_refresh_token = _issue_token_pair(db, user)
+    db.commit()
+
+    return AuthResponse(
+        access_token=access_token,
+        refresh_token=new_refresh_token,
+        user=_to_user_response(user),
     )

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,4 +1,6 @@
+import hashlib
 from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 
 from jose import JWTError, jwt
 from passlib.context import CryptContext
@@ -19,7 +21,13 @@ def get_password_hash(password: str) -> str:
 def create_token(subject: str, expires_minutes: int, token_type: str) -> str:
     now = datetime.now(tz=timezone.utc)
     expire = now + timedelta(minutes=expires_minutes)
-    payload = {"sub": subject, "type": token_type, "iat": int(now.timestamp()), "exp": int(expire.timestamp())}
+    payload = {
+        "sub": subject,
+        "type": token_type,
+        "jti": str(uuid4()),
+        "iat": int(now.timestamp()),
+        "exp": int(expire.timestamp()),
+    }
     return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
 
 
@@ -28,3 +36,7 @@ def decode_token(token: str) -> dict[str, object]:
         return jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
     except JWTError as exc:
         raise ValueError("invalid token") from exc
+
+
+def hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,5 @@
 from app.models.billing import BillingInvoice, Subscription
+from app.models.auth import RefreshToken
 from app.models.user import User
 
-__all__ = ["User", "Subscription", "BillingInvoice"]
-
+__all__ = ["User", "Subscription", "BillingInvoice", "RefreshToken"]

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class RefreshToken(Base):
+    __tablename__ = "refresh_tokens"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    token_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    user = relationship("User", back_populates="refresh_tokens")
+

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -22,4 +22,4 @@ class User(Base):
     )
 
     subscriptions = relationship("Subscription", back_populates="user", cascade="all, delete-orphan")
-
+    refresh_tokens = relationship("RefreshToken", back_populates="user", cascade="all, delete-orphan")

--- a/backend/tests/test_auth_flow.py
+++ b/backend/tests/test_auth_flow.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from app.db.base import Base
 from app.db.session import get_db
 from app.main import app
+from app.models.auth import RefreshToken
 
 
 TEST_DATABASE_URL = "sqlite:///./test_auto_investing.db"
@@ -50,8 +51,49 @@ def test_register_login_and_subscription() -> None:
     assert login_response.status_code == 200
     login_payload = login_response.json()
     assert login_payload["access_token"]
+    assert login_payload["refresh_token"]
+
+    db = TestingSessionLocal()
+    try:
+        token_row = db.query(RefreshToken).filter(RefreshToken.user_id == login_payload["user"]["id"]).first()
+        assert token_row is not None
+    finally:
+        db.close()
 
     token = login_payload["access_token"]
     sub_response = client.get("/v1/billing/subscription", headers={"Authorization": f"Bearer {token}"})
     assert sub_response.status_code == 200
     assert sub_response.json()["plan"] == "basic"
+
+
+def test_login_invalid_credentials_returns_401() -> None:
+    client = TestClient(app)
+    email = "login-invalid@example.com"
+    password = "password123"
+
+    register_response = client.post("/v1/auth/register", json={"email": email, "password": password})
+    assert register_response.status_code == 201
+
+    invalid = client.post("/v1/auth/login", json={"email": email, "password": "wrong-password"})
+    assert invalid.status_code == 401
+
+
+def test_refresh_token_rotation() -> None:
+    client = TestClient(app)
+    email = "refresh-rotation@example.com"
+    password = "password123"
+
+    register_response = client.post("/v1/auth/register", json={"email": email, "password": password})
+    assert register_response.status_code == 201
+    initial_refresh = register_response.json()["refresh_token"]
+
+    refresh_response = client.post("/v1/auth/refresh", json={"refresh_token": initial_refresh})
+    assert refresh_response.status_code == 200
+    new_refresh = refresh_response.json()["refresh_token"]
+    assert new_refresh != initial_refresh
+
+    replay_response = client.post("/v1/auth/refresh", json={"refresh_token": initial_refresh})
+    assert replay_response.status_code == 401
+
+    second_refresh_response = client.post("/v1/auth/refresh", json={"refresh_token": new_refresh})
+    assert second_refresh_response.status_code == 200

--- a/docs/API_OPENAPI.yaml
+++ b/docs/API_OPENAPI.yaml
@@ -84,6 +84,26 @@ paths:
                 properties:
                   verified:
                     type: boolean
+  /v1/auth/refresh:
+    post:
+      tags: [Auth]
+      summary: Rotate refresh token and issue new token pair
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshRequest'
+      responses:
+        '200':
+          description: Token rotated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /v1/billing/checkout-session:
     post:
       tags: [Billing]
@@ -392,6 +412,12 @@ components:
           type: string
           format: email
         password:
+          type: string
+    RefreshRequest:
+      type: object
+      required: [refresh_token]
+      properties:
+        refresh_token:
           type: string
     AuthResponse:
       type: object

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -10,6 +10,7 @@ erDiagram
   USERS ||--o{ STRATEGIES : "configures"
   USERS ||--o{ ALERT_CHANNELS : "receives"
   USERS ||--o{ DAILY_REPORTS : "gets"
+  USERS ||--o{ REFRESH_TOKENS : "auth"
 
   SUBSCRIPTIONS ||--o{ BILLING_INVOICES : "generates"
   EXCHANGE_ACCOUNTS ||--o{ ORDERS : "routes"
@@ -146,10 +147,18 @@ erDiagram
     string storage_url
     timestamptz created_at
   }
+
+  REFRESH_TOKENS {
+    uuid id PK
+    uuid user_id FK
+    string token_hash UK
+    timestamptz expires_at
+    timestamptz revoked_at
+    timestamptz created_at
+  }
 ```
 
 ## 설계 메모
 1. `strategies.risk_limits`는 일손실/포지션/변동성 제한을 JSON으로 저장해 초기 유연성을 확보한다.
 2. `orders.idempotency_key`를 unique로 강제해 중복 주문을 차단한다.
 3. 민감 정보(API 키)는 암호화된 문자열만 저장하고 평문은 저장하지 않는다.
-


### PR DESCRIPTION
## Summary
- persist refresh tokens in new refresh_tokens table
- add /v1/auth/refresh endpoint with one-time-use refresh token rotation
- reject revoked or unknown refresh tokens with 401
- add tests for invalid login and refresh rotation behavior
- update API and ERD docs for refresh token model and endpoint

## Validation
- cd backend && alembic upgrade head && pytest -q

Closes #2