### PR TITLE
Issue #3: TOTP MFA verify flow with lockout and audit log

### DIFF
--- a/backend/alembic/versions/20260213_000003_add_mfa_columns_and_auth_audit_logs.py
+++ b/backend/alembic/versions/20260213_000003_add_mfa_columns_and_auth_audit_logs.py
@@ -1,0 +1,47 @@
+"""add mfa columns and auth audit logs
+
+Revision ID: 20260213_000003
+Revises: 20260213_000002
+Create Date: 2026-02-13 09:15:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "20260213_000003"
+down_revision: Union[str, None] = "20260213_000002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("mfa_secret", sa.String(length=255), nullable=True))
+    op.add_column(
+        "users", sa.Column("mfa_failed_attempts", sa.Integer(), nullable=False, server_default=sa.text("0"))
+    )
+    op.add_column("users", sa.Column("mfa_locked_until", sa.DateTime(timezone=True), nullable=True))
+
+    op.create_table(
+        "auth_audit_logs",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("user_id", sa.String(length=36), nullable=True),
+        sa.Column("event_type", sa.String(length=50), nullable=False),
+        sa.Column("result", sa.String(length=20), nullable=False),
+        sa.Column("detail", sa.String(length=500), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_auth_audit_logs_user_id"), "auth_audit_logs", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_auth_audit_logs_user_id"), table_name="auth_audit_logs")
+    op.drop_table("auth_audit_logs")
+    op.drop_column("users", "mfa_locked_until")
+    op.drop_column("users", "mfa_failed_attempts")
+    op.drop_column("users", "mfa_secret")
+

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -4,14 +4,19 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy.orm import Session
 
+from app.api.deps import get_current_user
 from app.core.config import settings
 from app.core.security import create_token, decode_token, get_password_hash, hash_token, verify_password
+from app.core.totp import generate_base32_secret, provisioning_uri, verify_totp
 from app.db.session import get_db
+from app.models.audit import AuthAuditLog
 from app.models.auth import RefreshToken
 from app.models.billing import Subscription
 from app.models.user import User
 
 router = APIRouter()
+MAX_MFA_FAILURES = 5
+MFA_LOCK_MINUTES = 15
 
 
 class RegisterRequest(BaseModel):
@@ -26,6 +31,15 @@ class LoginRequest(BaseModel):
 
 class RefreshRequest(BaseModel):
     refresh_token: str
+
+
+class MFAVerifyRequest(BaseModel):
+    code: str = Field(min_length=6, max_length=8)
+
+
+class MFASetupResponse(BaseModel):
+    secret: str
+    otpauth_url: str
 
 
 class UserResponse(BaseModel):
@@ -54,6 +68,10 @@ def _issue_token_pair(db: Session, user: User) -> tuple[str, str]:
 
     db.add(RefreshToken(user_id=user.id, token_hash=hash_token(refresh_token), expires_at=expires_at))
     return access_token, refresh_token
+
+
+def _create_audit_log(db: Session, user_id: str | None, event_type: str, result: str, detail: str | None = None) -> None:
+    db.add(AuthAuditLog(user_id=user_id, event_type=event_type, result=result, detail=detail))
 
 
 @router.post("/register", status_code=status.HTTP_201_CREATED)
@@ -103,6 +121,58 @@ def login(payload: LoginRequest, db: Session = Depends(get_db)) -> AuthResponse:
     )
 
 
+@router.post("/mfa/setup")
+def mfa_setup(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)) -> MFASetupResponse:
+    if current_user.mfa_secret is None:
+        current_user.mfa_secret = generate_base32_secret()
+    otpauth_url = provisioning_uri(current_user.mfa_secret, account_name=current_user.email, issuer_name="Auto Investing")
+
+    _create_audit_log(db, current_user.id, "mfa_setup", "success")
+    db.commit()
+    return MFASetupResponse(secret=current_user.mfa_secret, otpauth_url=otpauth_url)
+
+
+@router.post("/mfa/verify")
+def mfa_verify(
+    payload: MFAVerifyRequest, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
+) -> dict[str, bool]:
+    now = datetime.now(tz=timezone.utc)
+    if not current_user.mfa_secret:
+        _create_audit_log(db, current_user.id, "mfa_verify", "failure", "mfa not setup")
+        db.commit()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="mfa not configured")
+
+    locked_until = current_user.mfa_locked_until
+    if locked_until and locked_until.tzinfo is None:
+        locked_until = locked_until.replace(tzinfo=timezone.utc)
+    if locked_until and locked_until > now:
+        _create_audit_log(db, current_user.id, "mfa_verify", "locked", "too many failures")
+        db.commit()
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="mfa temporarily locked")
+
+    verified = verify_totp(current_user.mfa_secret, payload.code, valid_window=1)
+
+    if not verified:
+        current_user.mfa_failed_attempts += 1
+        detail = f"failed attempts={current_user.mfa_failed_attempts}"
+        if current_user.mfa_failed_attempts >= MAX_MFA_FAILURES:
+            current_user.mfa_locked_until = now + timedelta(minutes=MFA_LOCK_MINUTES)
+            _create_audit_log(db, current_user.id, "mfa_verify", "locked", detail)
+            db.commit()
+            raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="mfa temporarily locked")
+
+        _create_audit_log(db, current_user.id, "mfa_verify", "failure", detail)
+        db.commit()
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid mfa code")
+
+    current_user.mfa_enabled = True
+    current_user.mfa_failed_attempts = 0
+    current_user.mfa_locked_until = None
+    _create_audit_log(db, current_user.id, "mfa_verify", "success")
+    db.commit()
+    return {"verified": True}
+
+
 @router.post("/refresh")
 def refresh_token(payload: RefreshRequest, db: Session = Depends(get_db)) -> AuthResponse:
     try:
@@ -126,10 +196,16 @@ def refresh_token(payload: RefreshRequest, db: Session = Depends(get_db)) -> Aut
         .first()
     )
     if stored_token is None:
+        _create_audit_log(db, user_id, "token_refresh", "failure", "revoked or unknown refresh token")
+        db.commit()
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="refresh token revoked or unknown")
 
     expires_at = datetime.fromtimestamp(token_exp, tz=timezone.utc) if isinstance(token_exp, int) else stored_token.expires_at
+    if isinstance(expires_at, datetime) and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
     if expires_at < datetime.now(tz=timezone.utc):
+        _create_audit_log(db, user_id, "token_refresh", "failure", "refresh token expired")
+        db.commit()
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="refresh token expired")
 
     user = db.query(User).filter(User.id == user_id).first()
@@ -138,6 +214,7 @@ def refresh_token(payload: RefreshRequest, db: Session = Depends(get_db)) -> Aut
 
     stored_token.revoked_at = datetime.now(tz=timezone.utc)
     access_token, new_refresh_token = _issue_token_pair(db, user)
+    _create_audit_log(db, user.id, "token_refresh", "success")
     db.commit()
 
     return AuthResponse(

--- a/backend/app/core/totp.py
+++ b/backend/app/core/totp.py
@@ -1,0 +1,51 @@
+import base64
+import hashlib
+import hmac
+import os
+import time
+from urllib.parse import quote
+
+
+def generate_base32_secret(num_bytes: int = 20) -> str:
+    secret = base64.b32encode(os.urandom(num_bytes)).decode("ascii")
+    return secret.rstrip("=")
+
+
+def _normalize_base32(secret: str) -> bytes:
+    padding = "=" * ((8 - (len(secret) % 8)) % 8)
+    return base64.b32decode((secret + padding).upper())
+
+
+def _hotp(secret: str, counter: int, digits: int = 6) -> str:
+    key = _normalize_base32(secret)
+    msg = counter.to_bytes(8, "big")
+    h = hmac.new(key, msg, hashlib.sha1).digest()
+    offset = h[-1] & 0x0F
+    code = ((h[offset] & 0x7F) << 24) | ((h[offset + 1] & 0xFF) << 16) | ((h[offset + 2] & 0xFF) << 8) | (h[offset + 3] & 0xFF)
+    return str(code % (10**digits)).zfill(digits)
+
+
+def generate_totp(secret: str, for_time: int | None = None, step: int = 30, digits: int = 6) -> str:
+    ts = for_time if for_time is not None else int(time.time())
+    counter = ts // step
+    return _hotp(secret, counter, digits=digits)
+
+
+def verify_totp(secret: str, code: str, valid_window: int = 1, step: int = 30, digits: int = 6) -> bool:
+    now = int(time.time())
+    counter = now // step
+    normalized = code.strip()
+    if not normalized.isdigit():
+        return False
+    for offset in range(-valid_window, valid_window + 1):
+        expected = _hotp(secret, counter + offset, digits=digits)
+        if hmac.compare_digest(expected, normalized):
+            return True
+    return False
+
+
+def provisioning_uri(secret: str, account_name: str, issuer_name: str) -> str:
+    account = quote(account_name)
+    issuer = quote(issuer_name)
+    return f"otpauth://totp/{issuer}:{account}?secret={secret}&issuer={issuer}&algorithm=SHA1&digits=6&period=30"
+

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.billing import BillingInvoice, Subscription
 from app.models.auth import RefreshToken
+from app.models.audit import AuthAuditLog
 from app.models.user import User
 
-__all__ = ["User", "Subscription", "BillingInvoice", "RefreshToken"]
+__all__ = ["User", "Subscription", "BillingInvoice", "RefreshToken", "AuthAuditLog"]

--- a/backend/app/models/audit.py
+++ b/backend/app/models/audit.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class AuthAuditLog(Base):
+    __tablename__ = "auth_audit_logs"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    user_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    result: Mapped[str] = mapped_column(String(20), nullable=False)
+    detail: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    user = relationship("User", back_populates="auth_audit_logs")
+

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Boolean, DateTime, String, func
+from sqlalchemy import Boolean, DateTime, Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -15,6 +15,9 @@ class User(Base):
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     role: Mapped[str] = mapped_column(String(20), nullable=False, default="user")
     mfa_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    mfa_secret: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    mfa_failed_attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    mfa_locked_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
@@ -23,3 +26,4 @@ class User(Base):
 
     subscriptions = relationship("Subscription", back_populates="user", cascade="all, delete-orphan")
     refresh_tokens = relationship("RefreshToken", back_populates="user", cascade="all, delete-orphan")
+    auth_audit_logs = relationship("AuthAuditLog", back_populates="user", cascade="all, delete-orphan")

--- a/backend/tests/test_auth_flow.py
+++ b/backend/tests/test_auth_flow.py
@@ -7,8 +7,11 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from app.db.base import Base
 from app.db.session import get_db
+from app.core.totp import generate_totp
 from app.main import app
+from app.models.audit import AuthAuditLog
 from app.models.auth import RefreshToken
+from app.models.user import User
 
 
 TEST_DATABASE_URL = "sqlite:///./test_auto_investing.db"
@@ -97,3 +100,89 @@ def test_refresh_token_rotation() -> None:
 
     second_refresh_response = client.post("/v1/auth/refresh", json={"refresh_token": new_refresh})
     assert second_refresh_response.status_code == 200
+
+
+def test_mfa_verify_success_and_audit_log() -> None:
+    client = TestClient(app)
+    email = "mfa-success@example.com"
+    password = "password123"
+
+    register_response = client.post("/v1/auth/register", json={"email": email, "password": password})
+    assert register_response.status_code == 201
+    access_token = register_response.json()["access_token"]
+
+    setup_response = client.post("/v1/auth/mfa/setup", headers={"Authorization": f"Bearer {access_token}"})
+    assert setup_response.status_code == 200
+    secret = setup_response.json()["secret"]
+    assert setup_response.json()["otpauth_url"]
+
+    code = generate_totp(secret)
+    verify_response = client.post(
+        "/v1/auth/mfa/verify",
+        json={"code": code},
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert verify_response.status_code == 200
+    assert verify_response.json()["verified"] is True
+
+    db = TestingSessionLocal()
+    try:
+        user = db.query(User).filter(User.email == email).first()
+        assert user is not None
+        assert user.mfa_enabled is True
+
+        audit_success = (
+            db.query(AuthAuditLog)
+            .filter(AuthAuditLog.user_id == user.id, AuthAuditLog.event_type == "mfa_verify", AuthAuditLog.result == "success")
+            .first()
+        )
+        assert audit_success is not None
+    finally:
+        db.close()
+
+
+def test_mfa_failure_limit_and_lock() -> None:
+    client = TestClient(app)
+    email = "mfa-fail-limit@example.com"
+    password = "password123"
+
+    register_response = client.post("/v1/auth/register", json={"email": email, "password": password})
+    assert register_response.status_code == 201
+    access_token = register_response.json()["access_token"]
+
+    setup_response = client.post("/v1/auth/mfa/setup", headers={"Authorization": f"Bearer {access_token}"})
+    assert setup_response.status_code == 200
+
+    for attempt in range(1, 6):
+        response = client.post(
+            "/v1/auth/mfa/verify",
+            json={"code": "000000"},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        if attempt < 5:
+            assert response.status_code == 401
+        else:
+            assert response.status_code == 429
+
+    locked_response = client.post(
+        "/v1/auth/mfa/verify",
+        json={"code": "000000"},
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert locked_response.status_code == 429
+
+    db = TestingSessionLocal()
+    try:
+        user = db.query(User).filter(User.email == email).first()
+        assert user is not None
+        assert user.mfa_failed_attempts >= 5
+        assert user.mfa_locked_until is not None
+
+        failure_logs = (
+            db.query(AuthAuditLog)
+            .filter(AuthAuditLog.user_id == user.id, AuthAuditLog.event_type == "mfa_verify")
+            .count()
+        )
+        assert failure_logs >= 5
+    finally:
+        db.close()

--- a/docs/API_OPENAPI.yaml
+++ b/docs/API_OPENAPI.yaml
@@ -60,6 +60,19 @@ paths:
                 $ref: '#/components/schemas/AuthResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /v1/auth/mfa/setup:
+    post:
+      tags: [Auth]
+      summary: Generate or return MFA TOTP secret for current user
+      responses:
+        '200':
+          description: MFA setup information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MFASetupResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /v1/auth/mfa/verify:
     post:
       tags: [Auth]
@@ -69,11 +82,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required: [code]
-              properties:
-                code:
-                  type: string
+              $ref: '#/components/schemas/MFAVerifyRequest'
       responses:
         '200':
           description: MFA verified
@@ -84,6 +93,16 @@ paths:
                 properties:
                   verified:
                     type: boolean
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          description: Too many failed attempts, temporarily locked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /v1/auth/refresh:
     post:
       tags: [Auth]
@@ -418,6 +437,22 @@ components:
       required: [refresh_token]
       properties:
         refresh_token:
+          type: string
+    MFAVerifyRequest:
+      type: object
+      required: [code]
+      properties:
+        code:
+          type: string
+          minLength: 6
+          maxLength: 8
+    MFASetupResponse:
+      type: object
+      required: [secret, otpauth_url]
+      properties:
+        secret:
+          type: string
+        otpauth_url:
           type: string
     AuthResponse:
       type: object

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -11,6 +11,7 @@ erDiagram
   USERS ||--o{ ALERT_CHANNELS : "receives"
   USERS ||--o{ DAILY_REPORTS : "gets"
   USERS ||--o{ REFRESH_TOKENS : "auth"
+  USERS ||--o{ AUTH_AUDIT_LOGS : "audits"
 
   SUBSCRIPTIONS ||--o{ BILLING_INVOICES : "generates"
   EXCHANGE_ACCOUNTS ||--o{ ORDERS : "routes"
@@ -25,6 +26,9 @@ erDiagram
     string password_hash
     string role
     boolean mfa_enabled
+    string mfa_secret
+    int mfa_failed_attempts
+    timestamptz mfa_locked_until
     string status
     timestamptz created_at
     timestamptz updated_at
@@ -154,6 +158,15 @@ erDiagram
     string token_hash UK
     timestamptz expires_at
     timestamptz revoked_at
+    timestamptz created_at
+  }
+
+  AUTH_AUDIT_LOGS {
+    uuid id PK
+    uuid user_id FK
+    string event_type
+    string result
+    string detail
     timestamptz created_at
   }
 ```


### PR DESCRIPTION
## Summary
- implement TOTP-based MFA setup and verify endpoints
- enforce failed-attempt limit with temporary lockout (5 failures, 15 minutes)
- add auth audit log table and write MFA verification events
- extend users schema with MFA secret and lock state fields
- update ERD and OpenAPI specs for MFA flow

## Validation
- cd backend && alembic upgrade head && pytest -q

Depends on #14
Closes #3