### PR TITLE
Issue #4: Billing checkout session API with validation and standard errors

### DIFF
--- a/backend/app/api/v1/endpoints/billing.py
+++ b/backend/app/api/v1/endpoints/billing.py
@@ -1,46 +1,64 @@
 from datetime import datetime, timedelta, timezone
+from typing import Literal
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
 from app.db.session import get_db
 from app.models.billing import Subscription
 from app.models.user import User
+from app.services.billing import BillingProviderError, get_billing_provider
 
 router = APIRouter()
 
 
 class CheckoutRequest(BaseModel):
-    plan: str
+    plan: Literal["basic", "pro", "premium"]
 
 
 @router.post("/checkout-session")
 def create_checkout_session(
-    payload: CheckoutRequest, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
+    payload: CheckoutRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    billing_provider=Depends(get_billing_provider),
 ) -> dict[str, str]:
+    try:
+        checkout = billing_provider.create_checkout_session(current_user.id, payload.plan)
+    except BillingProviderError as exc:
+        return JSONResponse(
+            status_code=502,
+            content={
+                "code": exc.code,
+                "message": exc.message,
+                "details": exc.details,
+            },
+        )
+
     now = datetime.now(tz=timezone.utc)
     subscription = db.query(Subscription).filter(Subscription.user_id == current_user.id).first()
     if subscription is None:
         subscription = Subscription(
             user_id=current_user.id,
             plan=payload.plan,
-            status="active",
+            status="pending_checkout",
             current_period_start=now,
             current_period_end=now + timedelta(days=30),
         )
         db.add(subscription)
     else:
         subscription.plan = payload.plan
-        subscription.status = "active"
+        subscription.status = "pending_checkout"
         subscription.current_period_start = now
         subscription.current_period_end = now + timedelta(days=30)
     db.commit()
 
     return {
-        "checkout_url": f"https://checkout.stripe.com/pay/stub-{payload.plan}",
-        "session_id": "cs_test_stub",
+        "checkout_url": checkout.checkout_url,
+        "session_id": checkout.session_id,
     }
 
 

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,2 @@
+# Service layer package.
+

--- a/backend/app/services/billing.py
+++ b/backend/app/services/billing.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from typing import Protocol
+from uuid import uuid4
+
+
+@dataclass
+class CheckoutSession:
+    checkout_url: str
+    session_id: str
+
+
+class BillingProviderError(Exception):
+    def __init__(self, code: str, message: str, details: dict[str, object] | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details or {}
+
+
+class BillingProvider(Protocol):
+    def create_checkout_session(self, user_id: str, plan: str) -> CheckoutSession:
+        ...
+
+
+class StripeStubBillingProvider:
+    def create_checkout_session(self, user_id: str, plan: str) -> CheckoutSession:
+        session_id = f"cs_test_{uuid4().hex[:16]}"
+        return CheckoutSession(
+            checkout_url=f"https://checkout.stripe.com/pay/stub-{plan}-{user_id[:8]}",
+            session_id=session_id,
+        )
+
+
+def get_billing_provider() -> BillingProvider:
+    return StripeStubBillingProvider()
+

--- a/backend/tests/test_billing_checkout.py
+++ b/backend/tests/test_billing_checkout.py
@@ -1,0 +1,112 @@
+from collections.abc import Generator
+import os
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.db.base import Base
+from app.db.session import get_db
+from app.main import app
+from app.models.billing import Subscription
+from app.services.billing import BillingProviderError, get_billing_provider
+
+
+TEST_DATABASE_URL = "sqlite:///./test_billing_checkout.db"
+engine = create_engine(TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, class_=Session)
+
+
+class FailingBillingProvider:
+    def create_checkout_session(self, user_id: str, plan: str) -> None:
+        _ = (user_id, plan)
+        raise BillingProviderError(
+            code="BILLING_STRIPE_ERROR",
+            message="stripe checkout session creation failed",
+            details={"reason": "stripe unavailable"},
+        )
+
+
+def override_get_db() -> Generator[Session, None, None]:
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def setup_module() -> None:
+    Base.metadata.create_all(bind=engine)
+    app.dependency_overrides[get_db] = override_get_db
+
+
+def teardown_module() -> None:
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(bind=engine)
+    if os.path.exists("test_billing_checkout.db"):
+        os.remove("test_billing_checkout.db")
+
+
+def _register_and_get_token(client: TestClient, email: str) -> str:
+    response = client.post("/v1/auth/register", json={"email": email, "password": "password123"})
+    assert response.status_code == 201
+    return response.json()["access_token"]
+
+
+def test_checkout_session_success() -> None:
+    client = TestClient(app)
+    token = _register_and_get_token(client, "billing-success@example.com")
+
+    response = client.post(
+        "/v1/billing/checkout-session",
+        json={"plan": "pro"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["checkout_url"].startswith("https://checkout.stripe.com/pay/stub-pro")
+    assert payload["session_id"].startswith("cs_test_")
+
+    db = TestingSessionLocal()
+    try:
+        sub = db.query(Subscription).order_by(Subscription.created_at.desc()).first()
+        assert sub is not None
+        assert sub.plan == "pro"
+        assert sub.status == "pending_checkout"
+    finally:
+        db.close()
+
+
+def test_checkout_session_plan_validation() -> None:
+    client = TestClient(app)
+    token = _register_and_get_token(client, "billing-invalid-plan@example.com")
+
+    response = client.post(
+        "/v1/billing/checkout-session",
+        json={"plan": "enterprise"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 422
+
+
+def test_checkout_session_provider_error_standard_code() -> None:
+    client = TestClient(app)
+    token = _register_and_get_token(client, "billing-provider-error@example.com")
+
+    app.dependency_overrides[get_billing_provider] = lambda: FailingBillingProvider()
+    try:
+        response = client.post(
+            "/v1/billing/checkout-session",
+            json={"plan": "basic"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    finally:
+        app.dependency_overrides.pop(get_billing_provider, None)
+
+    assert response.status_code == 502
+    payload = response.json()
+    assert payload["code"] == "BILLING_STRIPE_ERROR"
+    assert payload["message"] == "stripe checkout session creation failed"
+    assert payload["details"]["reason"] == "stripe unavailable"
+

--- a/docs/API_OPENAPI.yaml
+++ b/docs/API_OPENAPI.yaml
@@ -111,6 +111,12 @@ paths:
                     format: uri
                   session_id:
                     type: string
+        '502':
+          description: Stripe provider error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /v1/billing/subscription:
     get:
       tags: [Billing]


### PR DESCRIPTION
## Summary
- implement checkout session creation via injectable billing provider
- validate plan values (basic/pro/premium) at request schema level
- return standardized provider error payload with code, message, details on Stripe failures
- keep subscription in pending_checkout until payment webhook confirms active status
- add backend tests for success, plan validation, and provider failure cases

## Validation
- cd backend && pytest -q

Closes #4