### PR TITLE
Issue #5: Stripe webhook sync with signature verification and idempotency

### DIFF
--- a/backend/alembic/versions/20260213_000004_create_billing_webhook_events.py
+++ b/backend/alembic/versions/20260213_000004_create_billing_webhook_events.py
@@ -1,0 +1,41 @@
+"""create billing webhook events
+
+Revision ID: 20260213_000004
+Revises: 20260213_000001
+Create Date: 2026-02-13 10:20:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "20260213_000004"
+down_revision: Union[str, None] = "20260213_000001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "billing_webhook_events",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("stripe_event_id", sa.String(length=255), nullable=False),
+        sa.Column("event_type", sa.String(length=100), nullable=False),
+        sa.Column("processing_result", sa.String(length=20), nullable=False),
+        sa.Column("processed_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_billing_webhook_events_stripe_event_id"),
+        "billing_webhook_events",
+        ["stripe_event_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_billing_webhook_events_stripe_event_id"), table_name="billing_webhook_events")
+    op.drop_table("billing_webhook_events")
+

--- a/backend/app/api/v1/endpoints/billing.py
+++ b/backend/app/api/v1/endpoints/billing.py
@@ -1,22 +1,83 @@
 from datetime import datetime, timedelta, timezone
+import json
 from typing import Literal
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Header, Request
 from pydantic import BaseModel
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
+from app.core.config import settings
 from app.db.session import get_db
-from app.models.billing import Subscription
+from app.models.billing import BillingWebhookEvent, Subscription
 from app.models.user import User
-from app.services.billing import BillingProviderError, get_billing_provider
+from app.services.billing import (
+    BillingProviderError,
+    get_billing_provider,
+    verify_stripe_signature,
+)
 
 router = APIRouter()
 
 
 class CheckoutRequest(BaseModel):
     plan: Literal["basic", "pro", "premium"]
+
+
+def _to_datetime(value: object) -> datetime | None:
+    if isinstance(value, int):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    return None
+
+
+def _map_subscription_status(event_type: str, stripe_status: object) -> str | None:
+    if event_type == "invoice.paid":
+        return "active"
+    if event_type == "customer.subscription.deleted":
+        return "canceled"
+
+    stripe_to_local = {
+        "active": "active",
+        "trialing": "trialing",
+        "past_due": "past_due",
+        "canceled": "canceled",
+        "unpaid": "past_due",
+        "incomplete": "past_due",
+        "incomplete_expired": "canceled",
+    }
+    if isinstance(stripe_status, str):
+        return stripe_to_local.get(stripe_status)
+    return None
+
+
+def _find_subscription_from_event(db: Session, event_object: dict[str, object]) -> Subscription | None:
+    stripe_subscription_id = event_object.get("id")
+    if not isinstance(stripe_subscription_id, str):
+        stripe_subscription_id = event_object.get("subscription")
+
+    stripe_customer_id = event_object.get("customer")
+    metadata = event_object.get("metadata")
+    metadata_user_id = metadata.get("user_id") if isinstance(metadata, dict) else None
+
+    if isinstance(stripe_subscription_id, str):
+        sub = db.query(Subscription).filter(Subscription.stripe_subscription_id == stripe_subscription_id).first()
+        if sub:
+            return sub
+
+    if isinstance(stripe_customer_id, str):
+        sub = db.query(Subscription).filter(Subscription.stripe_customer_id == stripe_customer_id).first()
+        if sub:
+            return sub
+
+    if isinstance(metadata_user_id, str):
+        return (
+            db.query(Subscription)
+            .filter(Subscription.user_id == metadata_user_id)
+            .order_by(Subscription.created_at.desc())
+            .first()
+        )
+    return None
 
 
 @router.post("/checkout-session")
@@ -76,3 +137,94 @@ def get_subscription(db: Session = Depends(get_db), current_user: User = Depends
         "plan": subscription.plan,
         "status": subscription.status,
     }
+
+
+@router.post("/webhooks/stripe")
+async def stripe_webhook(
+    request: Request,
+    db: Session = Depends(get_db),
+    stripe_signature: str | None = Header(default=None, alias="Stripe-Signature"),
+) -> JSONResponse:
+    payload_bytes = await request.body()
+
+    if not verify_stripe_signature(payload_bytes, stripe_signature, settings.stripe_webhook_secret):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "code": "BILLING_WEBHOOK_SIGNATURE_INVALID",
+                "message": "invalid stripe webhook signature",
+                "details": None,
+            },
+        )
+
+    try:
+        event = json.loads(payload_bytes.decode("utf-8"))
+    except json.JSONDecodeError:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "code": "BILLING_WEBHOOK_PAYLOAD_INVALID",
+                "message": "invalid webhook payload",
+                "details": None,
+            },
+        )
+
+    event_id = event.get("id")
+    event_type = event.get("type")
+    if not isinstance(event_id, str) or not isinstance(event_type, str):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "code": "BILLING_WEBHOOK_EVENT_INVALID",
+                "message": "missing event id or type",
+                "details": None,
+            },
+        )
+
+    existing = db.query(BillingWebhookEvent).filter(BillingWebhookEvent.stripe_event_id == event_id).first()
+    if existing is not None:
+        return JSONResponse(status_code=200, content={"received": True, "duplicate": True})
+
+    event_object = event.get("data", {}).get("object", {})
+    if not isinstance(event_object, dict):
+        event_object = {}
+
+    subscription = _find_subscription_from_event(db, event_object)
+    status_synced = False
+    processing_result = "ignored"
+
+    if subscription is not None:
+        mapped_status = _map_subscription_status(event_type, event_object.get("status"))
+        if mapped_status:
+            subscription.status = mapped_status
+            status_synced = True
+
+        stripe_customer_id = event_object.get("customer")
+        if isinstance(stripe_customer_id, str):
+            subscription.stripe_customer_id = stripe_customer_id
+
+        stripe_subscription_id = event_object.get("id")
+        if not isinstance(stripe_subscription_id, str):
+            stripe_subscription_id = event_object.get("subscription")
+        if isinstance(stripe_subscription_id, str):
+            subscription.stripe_subscription_id = stripe_subscription_id
+
+        period_start = _to_datetime(event_object.get("current_period_start"))
+        period_end = _to_datetime(event_object.get("current_period_end"))
+        if period_start:
+            subscription.current_period_start = period_start
+        if period_end:
+            subscription.current_period_end = period_end
+
+        processing_result = "processed"
+
+    db.add(
+        BillingWebhookEvent(
+            stripe_event_id=event_id,
+            event_type=event_type,
+            processing_result=processing_result,
+        )
+    )
+    db.commit()
+
+    return JSONResponse(status_code=200, content={"received": True, "duplicate": False, "status_synced": status_synced})

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     jwt_algorithm: str = "HS256"
     access_token_expire_minutes: int = 30
     refresh_token_expire_minutes: int = 60 * 24 * 7
+    stripe_webhook_secret: str = "whsec_test"
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,4 @@
-from app.models.billing import BillingInvoice, Subscription
+from app.models.billing import BillingInvoice, BillingWebhookEvent, Subscription
 from app.models.user import User
 
-__all__ = ["User", "Subscription", "BillingInvoice"]
-
+__all__ = ["User", "Subscription", "BillingInvoice", "BillingWebhookEvent"]

--- a/backend/app/models/billing.py
+++ b/backend/app/models/billing.py
@@ -40,3 +40,12 @@ class BillingInvoice(Base):
 
     subscription = relationship("Subscription", back_populates="invoices")
 
+
+class BillingWebhookEvent(Base):
+    __tablename__ = "billing_webhook_events"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    stripe_event_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    event_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    processing_result: Mapped[str] = mapped_column(String(20), nullable=False, default="processed")
+    processed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/services/billing.py
+++ b/backend/app/services/billing.py
@@ -1,4 +1,7 @@
 from dataclasses import dataclass
+import hashlib
+import hmac
+import time
 from typing import Protocol
 from uuid import uuid4
 
@@ -34,3 +37,39 @@ class StripeStubBillingProvider:
 def get_billing_provider() -> BillingProvider:
     return StripeStubBillingProvider()
 
+
+def verify_stripe_signature(payload: bytes, signature_header: str | None, webhook_secret: str, tolerance_seconds: int = 300) -> bool:
+    if not signature_header:
+        return False
+
+    parts: dict[str, str] = {}
+    for segment in signature_header.split(","):
+        if "=" not in segment:
+            continue
+        key, value = segment.split("=", 1)
+        parts[key.strip()] = value.strip()
+
+    timestamp_raw = parts.get("t")
+    signature_v1 = parts.get("v1")
+    if not timestamp_raw or not signature_v1:
+        return False
+
+    try:
+        timestamp = int(timestamp_raw)
+    except ValueError:
+        return False
+
+    now = int(time.time())
+    if abs(now - timestamp) > tolerance_seconds:
+        return False
+
+    signed_payload = f"{timestamp}.{payload.decode('utf-8')}".encode("utf-8")
+    expected = hmac.new(webhook_secret.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_v1)
+
+
+def build_test_signature_header(payload: bytes, webhook_secret: str, timestamp: int | None = None) -> str:
+    ts = timestamp if timestamp is not None else int(time.time())
+    signed_payload = f"{ts}.{payload.decode('utf-8')}".encode("utf-8")
+    signature = hmac.new(webhook_secret.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
+    return f"t={ts},v1={signature}"

--- a/backend/tests/test_billing_webhook.py
+++ b/backend/tests/test_billing_webhook.py
@@ -1,0 +1,187 @@
+from collections.abc import Generator
+from datetime import datetime, timedelta, timezone
+import json
+import os
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.core.config import settings
+from app.db.base import Base
+from app.db.session import get_db
+from app.main import app
+from app.models.billing import BillingWebhookEvent, Subscription
+from app.services.billing import build_test_signature_header
+
+
+TEST_DATABASE_URL = "sqlite:///./test_billing_webhook.db"
+engine = create_engine(TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, class_=Session)
+
+
+def override_get_db() -> Generator[Session, None, None]:
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def setup_module() -> None:
+    Base.metadata.create_all(bind=engine)
+    app.dependency_overrides[get_db] = override_get_db
+
+
+def teardown_module() -> None:
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(bind=engine)
+    if os.path.exists("test_billing_webhook.db"):
+        os.remove("test_billing_webhook.db")
+
+
+def _register_user(client: TestClient, email: str) -> tuple[str, str]:
+    response = client.post("/v1/auth/register", json={"email": email, "password": "password123"})
+    assert response.status_code == 201
+    payload = response.json()
+    return payload["user"]["id"], payload["access_token"]
+
+
+def _post_signed_webhook(client: TestClient, event: dict[str, object]) -> object:
+    payload = json.dumps(event).encode("utf-8")
+    signature = build_test_signature_header(payload, settings.stripe_webhook_secret)
+    return client.post(
+        "/v1/billing/webhooks/stripe",
+        content=payload,
+        headers={"Stripe-Signature": signature, "Content-Type": "application/json"},
+    )
+
+
+def test_webhook_requires_valid_signature() -> None:
+    client = TestClient(app)
+    event = {"id": "evt_invalid_sig", "type": "invoice.paid", "data": {"object": {}}}
+    payload = json.dumps(event).encode("utf-8")
+
+    response = client.post(
+        "/v1/billing/webhooks/stripe",
+        content=payload,
+        headers={"Stripe-Signature": "t=1,v1=invalid", "Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+    assert response.json()["code"] == "BILLING_WEBHOOK_SIGNATURE_INVALID"
+
+
+def test_webhook_syncs_subscription_statuses() -> None:
+    client = TestClient(app)
+    user_id, token = _register_user(client, "webhook-sync@example.com")
+
+    checkout_response = client.post(
+        "/v1/billing/checkout-session",
+        json={"plan": "pro"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert checkout_response.status_code == 200
+
+    now = datetime.now(tz=timezone.utc)
+    start_ts = int(now.timestamp())
+    end_ts = int((now + timedelta(days=30)).timestamp())
+
+    paid_event = {
+        "id": "evt_paid_1",
+        "type": "invoice.paid",
+        "data": {
+            "object": {
+                "subscription": "sub_123",
+                "customer": "cus_123",
+                "metadata": {"user_id": user_id},
+                "current_period_start": start_ts,
+                "current_period_end": end_ts,
+            }
+        },
+    }
+    paid_response = _post_signed_webhook(client, paid_event)
+    assert paid_response.status_code == 200
+    assert paid_response.json()["status_synced"] is True
+
+    past_due_event = {
+        "id": "evt_sub_updated_1",
+        "type": "customer.subscription.updated",
+        "data": {
+            "object": {
+                "id": "sub_123",
+                "customer": "cus_123",
+                "status": "past_due",
+                "current_period_start": start_ts,
+                "current_period_end": end_ts,
+            }
+        },
+    }
+    past_due_response = _post_signed_webhook(client, past_due_event)
+    assert past_due_response.status_code == 200
+
+    canceled_event = {
+        "id": "evt_sub_deleted_1",
+        "type": "customer.subscription.deleted",
+        "data": {
+            "object": {
+                "id": "sub_123",
+                "customer": "cus_123",
+                "status": "canceled",
+            }
+        },
+    }
+    canceled_response = _post_signed_webhook(client, canceled_event)
+    assert canceled_response.status_code == 200
+
+    db = TestingSessionLocal()
+    try:
+        sub = (
+            db.query(Subscription)
+            .filter(Subscription.user_id == user_id)
+            .order_by(Subscription.created_at.desc())
+            .first()
+        )
+        assert sub is not None
+        assert sub.stripe_customer_id == "cus_123"
+        assert sub.stripe_subscription_id == "sub_123"
+        assert sub.status == "canceled"
+    finally:
+        db.close()
+
+
+def test_webhook_is_idempotent_for_duplicate_event() -> None:
+    client = TestClient(app)
+    user_id, token = _register_user(client, "webhook-idempotent@example.com")
+    checkout_response = client.post(
+        "/v1/billing/checkout-session",
+        json={"plan": "basic"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert checkout_response.status_code == 200
+
+    event = {
+        "id": "evt_duplicate_1",
+        "type": "invoice.paid",
+        "data": {
+            "object": {
+                "subscription": "sub_dup_1",
+                "customer": "cus_dup_1",
+                "metadata": {"user_id": user_id},
+            }
+        },
+    }
+    first = _post_signed_webhook(client, event)
+    second = _post_signed_webhook(client, event)
+
+    assert first.status_code == 200
+    assert first.json()["duplicate"] is False
+    assert second.status_code == 200
+    assert second.json()["duplicate"] is True
+
+    db = TestingSessionLocal()
+    try:
+        count = db.query(BillingWebhookEvent).filter(BillingWebhookEvent.stripe_event_id == "evt_duplicate_1").count()
+        assert count == 1
+    finally:
+        db.close()
+

--- a/docs/API_OPENAPI.yaml
+++ b/docs/API_OPENAPI.yaml
@@ -128,6 +128,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Subscription'
+  /v1/billing/webhooks/stripe:
+    post:
+      tags: [Billing]
+      summary: Process Stripe webhook events and sync subscription status
+      security: []
+      parameters:
+        - in: header
+          name: Stripe-Signature
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Webhook processed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  received:
+                    type: boolean
+                  duplicate:
+                    type: boolean
+                  status_synced:
+                    type: boolean
+        '400':
+          description: Invalid signature or payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /v1/exchange-accounts:
     get:
       tags: [Exchange Accounts]
@@ -441,7 +478,7 @@ components:
           $ref: '#/components/schemas/Plan'
         status:
           type: string
-          enum: [trialing, active, past_due, canceled]
+          enum: [trialing, pending_checkout, active, past_due, canceled]
         current_period_start:
           type: string
           format: date-time

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -12,6 +12,7 @@ erDiagram
   USERS ||--o{ DAILY_REPORTS : "gets"
 
   SUBSCRIPTIONS ||--o{ BILLING_INVOICES : "generates"
+  SUBSCRIPTIONS ||--o{ BILLING_WEBHOOK_EVENTS : "sync_events"
   EXCHANGE_ACCOUNTS ||--o{ ORDERS : "routes"
   STRATEGIES ||--o{ ORDERS : "creates"
   ORDERS ||--o{ FILLS : "executes"
@@ -50,6 +51,14 @@ erDiagram
     string status
     timestamptz paid_at
     timestamptz created_at
+  }
+
+  BILLING_WEBHOOK_EVENTS {
+    uuid id PK
+    string stripe_event_id UK
+    string event_type
+    string processing_result
+    timestamptz processed_at
   }
 
   EXCHANGE_ACCOUNTS {
@@ -152,4 +161,3 @@ erDiagram
 1. `strategies.risk_limits`는 일손실/포지션/변동성 제한을 JSON으로 저장해 초기 유연성을 확보한다.
 2. `orders.idempotency_key`를 unique로 강제해 중복 주문을 차단한다.
 3. 민감 정보(API 키)는 암호화된 문자열만 저장하고 평문은 저장하지 않는다.
-


### PR DESCRIPTION
## Summary
- add Stripe webhook endpoint at /v1/billing/webhooks/stripe
- verify Stripe signature before processing events
- synchronize subscription status for active, past_due, canceled flows
- ensure idempotency by persisting processed stripe event ids
- add webhook event table migration and end-to-end webhook tests
- update OpenAPI and ERD docs

## Validation
- cd backend && DATABASE_URL='sqlite:///./auto_investing_issue5.db' alembic upgrade head && pytest -q

Depends on #16
Closes #5